### PR TITLE
Fix Disk Swap HTTP server build issues

### DIFF
--- a/Source/Core/Core/HTTP/DiscSwapServer.cpp
+++ b/Source/Core/Core/HTTP/DiscSwapServer.cpp
@@ -12,6 +12,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/Thread.h"
 #include "Common/FileUtil.h"
+#include "Common/SocketContext.h"
 #include "Core/Core.h"
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/System.h"
@@ -54,7 +55,11 @@ void SendResponse(sf::TcpSocket& sock, const std::string& status, const std::str
       << "Content-Length: " << body.size() << "\r\n"
       << "Connection: close\r\n\r\n" << body;
   const std::string resp = out.str();
-  sock.send(resp.c_str(), resp.size());
+  const sf::Socket::Status send_status = sock.send(resp.c_str(), resp.size());
+  if (send_status != sf::Socket::Status::Done)
+  {
+    ERROR_LOG_FMT(CORE, "Failed to send HTTP response: {}", static_cast<int>(send_status));
+  }
 }
 
 void HandleRequest(sf::TcpSocket& sock)


### PR DESCRIPTION
## Summary
- include `SocketContext.h` in DiscSwapServer
- check the result of `sock.send` to avoid nodiscard build error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cda3e5ed88330b4699b29a76943ec